### PR TITLE
Hide Badge Display on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,8 @@ Submit an issue on GitHub and add as much information as you can about the bug, 
 - Flask
 - A bunch of flask modules
 
-<div align="center">
+<!-- <div align="center">
 <a href="docs/LICENSE.md"><img src="https://img.shields.io/github/license/pvcodes/pi_chatter/?style=flat-square" alt="MIT license"></a>
-</div>
-
+</div> -->
 
 #### Wandering why all the repos are forked from <b>[pvcodes-zz](https://github.com/pvcodes-zz)</b>. Read [here](https://github.com/pvcodes/github-repo-cloner#where-did-the-idea-came-from)


### PR DESCRIPTION
This temporarily fixes #3 by commenting out the section of code that displays the badge, if you prefer me to delete the code entirely or create the LICENSE.md file for the MIT license do reply here. 